### PR TITLE
feat: add desktop bridge handshake

### DIFF
--- a/src/interface/index.html
+++ b/src/interface/index.html
@@ -31,6 +31,7 @@
 
     <!-- Preload services as globals before module system -->
     <script src="js/services/color-manager.js"></script>
+    <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
 
     <!-- Entry point — reorganized per issue #108 -->
     <script type="module" src="js/app.js"></script>

--- a/src/interface/js/app.js
+++ b/src/interface/js/app.js
@@ -8,6 +8,7 @@ import './core/router.js';
 import './services/auth.service.js';
 import './services/stats-manager.js';
 import './services/color-manager.js';
+import './services/bridge.service.js';
 
 // Core (depends on authService + router)
 import './core/route-protection.js';

--- a/src/interface/js/services/bridge.service.js
+++ b/src/interface/js/services/bridge.service.js
@@ -1,0 +1,33 @@
+/**
+ * Desktop bridge service for PyQt6 WebChannel.
+ */
+
+function bridgeReady() {
+  return typeof window.qt !== "undefined" && window.qt.webChannelTransport && typeof QWebChannel !== "undefined";
+}
+
+function setBridge(channel) {
+  window.bridge = channel.objects.bridge;
+  window.dispatchEvent(new CustomEvent("bridge:ready", { detail: { connected: true } }));
+  if (window.bridge && typeof window.bridge.emit === "function") {
+    window.bridge.emit("app:ready", { timestamp: new Date().toISOString() });
+  }
+}
+
+function initBridge() {
+  if (!bridgeReady()) {
+    window.bridge = null;
+    window.dispatchEvent(new CustomEvent("bridge:ready", { detail: { connected: false } }));
+    return;
+  }
+
+  new QWebChannel(qt.webChannelTransport, (channel) => {
+    setBridge(channel);
+  });
+}
+
+window.addEventListener("app:ack", (event) => {
+  console.info("Desktop bridge connected:", event.detail);
+});
+
+initBridge();

--- a/src/main.py
+++ b/src/main.py
@@ -56,6 +56,7 @@ class AppController:
     def _wire_service_events(self) -> None:
         events = self._services.events
         sessions = self._services.sessions
+        events.on("app:ready", self._handle_app_ready)
         events.on("timer:start", lambda payload: self._start_session(sessions, payload))
         events.on("timer:pause", lambda _payload: sessions.pause())
         events.on("timer:resume", lambda _payload: sessions.resume())
@@ -63,6 +64,15 @@ class AppController:
 
     def _shutdown_services(self) -> None:
         self._services.timer.shutdown()
+
+    def _handle_app_ready(self, payload: dict[str, object]) -> None:
+        self._services.events.emit(
+            "app:ack",
+            {
+                "status": "connected",
+                "timestamp": payload.get("timestamp"),
+            },
+        )
 
     def _start_session(self, sessions: SessionManager, payload: dict[str, object]) -> None:
         goal_id = payload.get("goal_id")

--- a/src/utils/bridge.py
+++ b/src/utils/bridge.py
@@ -11,6 +11,7 @@ from PyQt6.QtWebEngineWidgets import QWebEngineView
 from services.event_emitter import EventEmitter
 
 DEFAULT_FORWARD_EVENTS = (
+    "app:ack",
     "timer:start",
     "timer:tick",
     "timer:pause",


### PR DESCRIPTION
Initialize QWebChannel in the frontend and emit a ready/ack handshake.

Load qwebchannel.js in the UI shell.

Implements: #609